### PR TITLE
Exclude dot dirs

### DIFF
--- a/etc/bash_completion.d/go
+++ b/etc/bash_completion.d/go
@@ -32,7 +32,7 @@ function _go() {
       ;;
     *)
       files=$(find ${PWD} -mindepth 1 -maxdepth 1 -type f -iname "*.go" -exec basename {} \;)
-      dirs=$(find ${PWD} -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+      dirs=$(find ${PWD} -mindepth 1 -maxdepth 1 -type d -not -name ".*" -exec basename {} \;)
       repl="${files} ${dirs}"
       COMPREPLY=($(compgen -W "${repl}" -- ${cur}))
       ;;


### PR DESCRIPTION
Don't know about other OS's, but on Linux there is often a good number of "hidden" directories whose name begins with a dot.

Excluding those seems like a good idea to me.
